### PR TITLE
Bug fixes + ability to ignore char sequences in strings

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 // Marble versioning information
 #define MARBLE_MAJOR_CODENAME "Clearies"
-#define MARBLE_VERSION "0.4.0"
+#define MARBLE_VERSION "0.5.0"
 
 #define MAX_KEYWORD_SIZE 15
 #define MAX_OPERATORS_SIZE 3

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -78,5 +78,8 @@ private:
     TokenFactory tokenFactory;
     Logger* logger;
     const char* filename;
+    /* Char sequences such as "/n" will be treated as "\n" and not a new line if this is set to true. This is for all char sequences
+     * this is set to true automatically when prepending ":" before any string, for example :"Hello\nworld" */
+    bool ignore_char_sequence;
 };
 #endif

--- a/src/stdmods/filemod/src/filemod_file.cpp
+++ b/src/stdmods/filemod/src/filemod_file.cpp
@@ -192,6 +192,7 @@ Class *FileModule_File::registerClass(ModuleSystem *moduleSystem)
      * Writes the given string to the file specified by the filename.
      * If the file does not exist it creates it, if it does exist it overwrites it
      * 
+     * Available Since v0.4.0
      * @works_without_class
      * function file_put_contents(string filename, string data) : void
      */
@@ -205,6 +206,7 @@ Class *FileModule_File::registerClass(ModuleSystem *moduleSystem)
      * will be treated as a single 8 bit character all other bits of the number are ignored. For example if you have a number with the value 0xffff. Only 0xff will be used
      * If the file does not exist it creates it, if it does exist it overwrites it
      * 
+     * Available Since v0.4.0
      * @works_without_class
      * function file_put_binary_contents(string filename, number[] data) : void
      */

--- a/src/stdmods/filemod/src/filemod_file.cpp
+++ b/src/stdmods/filemod/src/filemod_file.cpp
@@ -168,6 +168,7 @@ Class *FileModule_File::registerClass(ModuleSystem *moduleSystem)
      * 
      * Reads the entire file into memory as a string and returns the file contents.
      * Important to note that this returns only valid ASCII string data. Please use file_get_binary_contents for binary files
+     * 
      * @works_without_class
      * function file_get_contents(string filename) : string
      */
@@ -179,6 +180,8 @@ Class *FileModule_File::registerClass(ModuleSystem *moduleSystem)
      * 
      * Reads the entire file into memory, returns the file contents as a number array that holds 8 bit characters in each index.
      * Use this function for reading binary files
+     * 
+     * Available Since v0.4.0
      * @works_without_class
      * function file_get_binary_contents(string filename) : number[]
      */
@@ -192,7 +195,6 @@ Class *FileModule_File::registerClass(ModuleSystem *moduleSystem)
      * Writes the given string to the file specified by the filename.
      * If the file does not exist it creates it, if it does exist it overwrites it
      * 
-     * Available Since v0.4.0
      * @works_without_class
      * function file_put_contents(string filename, string data) : void
      */

--- a/src/system/interpreter.cpp
+++ b/src/system/interpreter.cpp
@@ -622,7 +622,7 @@ std::string Interpreter::mergeCodeAndDataForSplit(split *split)
     if (split->has_data)
     {
         output_data = handleRawDataForSplit(split);
-        result += "\"" + str_replace(output_data, "\"", "\\\"") + "\";\n";
+        result += ":\"" + str_replace(output_data, "\"", "\\\"") + "\";\n";
     }
 
     // Run the code


### PR DESCRIPTION
* Fixed a bug where char sequences were possible outside marble tags.
* Implemented the ability to ignore char sequences in a marble string using the ":" operator.

Example of ignoring char sequences
`print(:"Hello\nworld");` prints out Hello\nworld instead of Hello (new line) world