### PR TITLE
Fixed a bug where the ignore char sequence operator ':' even ignores …

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 // Marble versioning information
 #define MARBLE_MAJOR_CODENAME "Clearies"
-#define MARBLE_VERSION "0.6.1"
+#define MARBLE_VERSION "0.6.2"
 
 #define MAX_KEYWORD_SIZE 15
 #define MAX_OPERATORS_SIZE 3

--- a/src/system/lexer.cpp
+++ b/src/system/lexer.cpp
@@ -289,12 +289,13 @@ std::string Lexer::get_string(const char **ptr, PosInfo &posInfo)
     // Lets loop until we find an ending string seperator.
     while (bounds_safe(our_ptr) && !is_string_seperator(c))
     {
-        if (c == '\\' && !ignore_char_sequence)
+        int next_byte = bounds_safe(our_ptr+1) ? *(our_ptr+1) : -1;
+        if (c == '\\' && (!ignore_char_sequence || next_byte == '"'))
         {
             /* Some characters are valid in strings such as carriage returns and new lines \r\n
              * Let's handle it here*/
             our_ptr += 1;
-            c = *our_ptr;
+            c = next_byte;
             c = get_char_for_sequence(c);
         }
         value += c;


### PR DESCRIPTION
…the slashing of quotes. We really wanted it to ignore everything except the slashing of quotes as the char sequence operator is to be used with strings